### PR TITLE
Add credscan suppression and add CODEOWNERS

### DIFF
--- a/.azure-pipelines/ci-scan.yml
+++ b/.azure-pipelines/ci-scan.yml
@@ -7,6 +7,7 @@ steps:
   inputs:
     toolMajorVersion: V2
     debugMode: false
+    suppressionsFile: .config/CredScanSuppressions.json
 
 - task: TSLint@1
   inputs:

--- a/.config/CredScanSuppressions.json
+++ b/.config/CredScanSuppressions.json
@@ -1,0 +1,9 @@
+{
+  "tool": "Credential Scanner",
+  "suppressions": [
+    {
+      "placeholder": "GitHubRegistryPassword",
+      "_justification": "This is an asset type and does not really contain a secret"
+    }
+  ]
+}

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*    @bishal-pdmsft @vineetmimrot @kanika1894 @anuragc617


### PR DESCRIPTION
Two changes:
1. Suppressed credscan error as it was pointing to a variable which actually is not a secret. This will enable us to force ci-scan check on future PRs.
2. Add CODEOWERS file so that reviewers will get assigned automatically for PRs