### PR TITLE
Adding notification post GitHubPat input

### DIFF
--- a/src/configure/configure.ts
+++ b/src/configure/configure.ts
@@ -232,10 +232,13 @@ class Orchestrator {
     private async getRepositoryAnalysis() {
         if (this.inputs.sourceRepository.repositoryProvider === RepositoryProvider.Github) {
             await this.getGithubPatToken();
-            return await telemetryHelper.executeFunctionWithTimeTelemetry(async () => {
-                return await new RepoAnalysisHelper(this.inputs.azureSession, this.inputs.githubPATToken).getRepositoryAnalysis(
-                    this.inputs.sourceRepository, this.inputs.pipelineConfiguration.workingDirectory.split('/').join('\\'));
-            }, TelemetryKeys.RepositoryAnalysisDuration);
+            return await vscode.window.withProgress(
+                { location: vscode.ProgressLocation.Notification, title: Messages.FetchingRepoDetails },
+                () => telemetryHelper.executeFunctionWithTimeTelemetry(async () => {
+                    return await new RepoAnalysisHelper(this.inputs.azureSession, this.inputs.githubPATToken).getRepositoryAnalysis(
+                        this.inputs.sourceRepository, this.inputs.pipelineConfiguration.workingDirectory.split('/').join('\\'));
+                }, TelemetryKeys.RepositoryAnalysisDuration)
+            );
         }
         return null;
     }

--- a/src/configure/configure.ts
+++ b/src/configure/configure.ts
@@ -482,7 +482,7 @@ class Orchestrator {
 
         if (!extensionVariables.templateServiceEnabled) {
             var localPipelines = await vscode.window.withProgress(
-                { location: vscode.ProgressLocation.Notification, title: Messages.analyzingRepo },
+                { location: vscode.ProgressLocation.Notification, title: Messages.fetchingTemplates },
                 () => templateHelper.analyzeRepoAndListAppropriatePipeline(
                     this.inputs.sourceRepository.localPath,
                     this.inputs.sourceRepository.repositoryProvider,
@@ -492,7 +492,7 @@ class Orchestrator {
             appropriatePipelines = localPipelines;
         } else {
             var remotePipelines: PipelineTemplate[] = await vscode.window.withProgress(
-                { location: vscode.ProgressLocation.Notification, title: Messages.analyzingRepo },
+                { location: vscode.ProgressLocation.Notification, title: Messages.fetchingTemplates },
                 () => templateHelper.analyzeRepoAndListAppropriatePipeline2(
                     this.inputs.azureSession,
                     this.inputs.sourceRepository.localPath,

--- a/src/configure/configure.ts
+++ b/src/configure/configure.ts
@@ -233,7 +233,7 @@ class Orchestrator {
         if (this.inputs.sourceRepository.repositoryProvider === RepositoryProvider.Github) {
             await this.getGithubPatToken();
             return await vscode.window.withProgress(
-                { location: vscode.ProgressLocation.Notification, title: Messages.FetchingRepoDetails },
+                { location: vscode.ProgressLocation.Notification, title: Messages.AnalyzingRepo },
                 () => telemetryHelper.executeFunctionWithTimeTelemetry(async () => {
                     return await new RepoAnalysisHelper(this.inputs.azureSession, this.inputs.githubPATToken).getRepositoryAnalysis(
                         this.inputs.sourceRepository, this.inputs.pipelineConfiguration.workingDirectory.split('/').join('\\'));

--- a/src/configure/resources/messages.ts
+++ b/src/configure/resources/messages.ts
@@ -108,4 +108,5 @@ export class Messages {
     public static cannotCreateGitHubRepository = "New GitHub repository could not be created as the repository with the same name already exists";
     public static languageNotSupported = "The language of the repository selected is not supported.";
     public static UnableToGetTemplateParameters = "Unable to get parameters for the selected template.";
+    public static FetchingRepoDetails = "Fetching repository details";
 }

--- a/src/configure/resources/messages.ts
+++ b/src/configure/resources/messages.ts
@@ -108,5 +108,5 @@ export class Messages {
     public static cannotCreateGitHubRepository = "New GitHub repository could not be created as the repository with the same name already exists";
     public static languageNotSupported = "The language of the repository selected is not supported.";
     public static UnableToGetTemplateParameters = "Unable to get parameters for the selected template.";
-    public static FetchingRepoDetails = "Fetching repository details";
+    public static AnalyzingRepo = "Analyzing your repository";
 }

--- a/src/configure/resources/messages.ts
+++ b/src/configure/resources/messages.ts
@@ -2,7 +2,7 @@ export class Messages {
     public static acquireTokenFromRefreshTokenFailed: string = 'Acquiring token with refresh token failed. Error: %s.';
     public static addAzurePipelinesYmlFile: string = 'Added Azure Pipelines YAML definition.';
     public static addGitHubWorkflowYmlFile: string = 'Added GitHub Workflow YAML definition.';
-    public static analyzingRepo: string = 'Analyzing your repository';
+    public static fetchingTemplates: string = 'Fetching templates';
     public static appKindIsNotSupported: string = 'App type "%s" is not yet supported.';
     public static azureResourceIsNull: string = 'ArgumentNullException: resource. The Azure target resource is empty, kindly select a resource and try again.';
     public static azureAccountExntesionUnavailable: string = 'Azure-Account extension could not be fetched. Please ensure it\'s installed and activated.';


### PR DESCRIPTION
Since the user isn't aware of the repo analysis call being made post the input of GitHubPat, it is likely that he will try creating a new flow using Ctrl+Shift+P which creates faulty telemetry logs. Therefore, adding additional notification to prevent such scenarios.