### PR TITLE
Show personal account in org list

### DIFF
--- a/src/configure/configurers/localGithubWorkflowConfigurer.ts
+++ b/src/configure/configurers/localGithubWorkflowConfigurer.ts
@@ -43,18 +43,19 @@ export class LocalGitHubWorkflowConfigurer implements Configurer {
         this.githubClient = new GithubClient(inputs.githubPATToken, inputs.sourceRepository.remoteUrl);
         inputs.isNewOrganization = false;
         if (!inputs.sourceRepository.remoteUrl) {
-            let githubOrganizations = await this.githubClient.listOrganizations();
+            const githubOrganizations = await this.githubClient.listOrganizations();
 
             if (githubOrganizations && githubOrganizations.length > 0) {
-                let selectedOrganization = await this.controlProvider.showQuickPick(
+                const selectedOrganization = await this.controlProvider.showQuickPick(
                     constants.SelectGitHubOrganization,
                     githubOrganizations.map(x => { return { label: x.login }; }),
                     { placeHolder: Messages.selectGitHubOrganizationName },
                     TelemetryKeys.OrganizationListCount);
                 inputs.organizationName = selectedOrganization.label;
+                const isUserAccount = githubOrganizations.find((x) => x.login === selectedOrganization.label).isUserAccount;
 
                 try {
-                    let newGitHubRepo = await generateGitHubRepository(inputs.organizationName, inputs.sourceRepository.localPath, this.githubClient) as GitHubRepo;
+                    const newGitHubRepo = await generateGitHubRepository(inputs.organizationName, inputs.sourceRepository.localPath, this.githubClient, isUserAccount) as GitHubRepo;
                     this.githubClient.setRepoUrl(newGitHubRepo.html_url);
                     inputs.sourceRepository.remoteName = newGitHubRepo.name;
                     inputs.sourceRepository.remoteUrl = newGitHubRepo.html_url + ".git";
@@ -71,7 +72,7 @@ export class LocalGitHubWorkflowConfigurer implements Configurer {
             }
             else {
                 vscode.window.showErrorMessage(Messages.createGitHubOrganization);
-                let error = new Error(Messages.createGitHubOrganization);
+                const error = new Error(Messages.createGitHubOrganization);
                 telemetryHelper.logError(Layer, TracePoints.NoGitHubOrganizationExists, error);
                 throw error;
             }

--- a/src/configure/helper/commonHelper.ts
+++ b/src/configure/helper/commonHelper.ts
@@ -15,21 +15,21 @@ export async function sleepForMilliSeconds(timeInMs: number): Promise<void> {
     });
 }
 
-export async function generateGitHubRepository(orgName: string, localPath: string, githubClient: GithubClient): Promise<GitHubRepo> {
+export async function generateGitHubRepository(orgName: string, localPath: string, githubClient: GithubClient, isUserAccount: boolean = false): Promise<GitHubRepo> {
     let repoName = localPath.substring(localPath.lastIndexOf("\\") + 1).substring(localPath.lastIndexOf("/") + 1);
-    let repoDetails = await githubClient.createGithubRepo(orgName, repoName) as GitHubRepo;
+    let repoDetails = await githubClient.createGithubRepo(orgName, repoName, isUserAccount) as GitHubRepo;
     // Case : GitHub Repository name is same as the local repo
     if (repoDetails) {
         return repoDetails;
     }
     //Case: Local repository name is not available, therefore organization name has been appended
     repoName = repoName + "_" + orgName;
-    repoDetails = await githubClient.createGithubRepo(orgName, repoName) as GitHubRepo;
+    repoDetails = await githubClient.createGithubRepo(orgName, repoName, isUserAccount) as GitHubRepo;
     if (repoDetails) {
         return repoDetails;
     }
     //Case: If the above two repository names are not available, uuid is also appended
-    return await githubClient.createGithubRepo(orgName, repoName + "_" + uuid().substr(0, 5));
+    return await githubClient.createGithubRepo(orgName, repoName + "_" + uuid().substr(0, 5), isUserAccount);
 }
 
 export function generateDevOpsOrganizationName(userName: string, repositoryName: string): string {

--- a/src/configure/model/models.ts
+++ b/src/configure/model/models.ts
@@ -58,6 +58,7 @@ export class GitHubOrganization {
     id: number;
     url: string;
     repos_url: string;
+    isUserAccount?: boolean = false;
 }
 
 export class GitHubRepo {

--- a/tslint.json
+++ b/tslint.json
@@ -1,5 +1,7 @@
 {
-	"rulesDirectory": ["node_modules/tslint-microsoft-contrib"],
+	"rulesDirectory": [
+		"node_modules/tslint-microsoft-contrib"
+	],
 	"rules": {
 		"no-string-throw": true,
 		"no-unused-expression": true,
@@ -29,17 +31,17 @@
 		"max-line-length": [
 			true,
 			{
-			  "limit": 135,
-			  "ignore-pattern": "^import [^,]+ from |^export | implements"
+				"limit": 135,
+				"ignore-pattern": "^import [^,]+ from |^export | implements"
 			}
-		  ],
+		],
 		"trailing-comma": false,
 		"one-line": false,
 		"ordered-imports": [
 			true,
 			{
-			  "import-sources-order": "case-insensitive",
-			  "named-imports-order": "case-insensitive"
+				"import-sources-order": "case-insensitive",
+				"named-imports-order": "case-insensitive"
 			}
 		],
 		"no-constant-condition": [
@@ -47,8 +49,14 @@
 			{
 				"checkLoops": false
 			}
-		]
+		],
+		"no-angle-bracket-type-assertion": false,
+		"object-literal-sort-keys": false,
+		"prefer-type-cast": false
 	},
 	"defaultSeverity": "warning",
-	"extends": ["tslint-microsoft-contrib/recommended", "tslint:recommended"]
+	"extends": [
+		"tslint-microsoft-contrib/recommended",
+		"tslint:recommended"
+	]
 }


### PR DESCRIPTION
This PR appends GitHub owner account into org list. Many users doesn't have org, so this feature will allow users to setup workflow in their default account. 