### PR TITLE
More Tolerant Conditions for Visibility Rules

### DIFF
--- a/src/configure/templateInputHelper/utilities/VisibilityHelper.ts
+++ b/src/configure/templateInputHelper/utilities/VisibilityHelper.ts
@@ -60,7 +60,7 @@ export class VisibilityHelper {
     }
 
     private static getPredicateRule(visibleRule: string): IPredicate {
-        let reg = /([a-zA-Z0-9 ]+)([!=<>]+)([a-zA-Z0-9. ]+)|([a-zA-Z0-9 ]+(?=NotContains|NotEndsWith|NotStartsWith))(NotContains|NotEndsWith|NotStartsWith)([a-zA-Z0-9. ]+)|([a-zA-Z0-9 ]+(?=Contains|EndsWith|StartsWith))(Contains|EndsWith|StartsWith)([a-zA-Z0-9. ]+)/g;
+        let reg = /([a-zA-Z0-9 ]+)([!=<>]+)([a-zA-Z0-9. \-\_]+)|([a-zA-Z0-9 ]+(?=NotContains|NotEndsWith|NotStartsWith))(NotContains|NotEndsWith|NotStartsWith)([a-zA-Z0-9. \-\_]+)|([a-zA-Z0-9 ]+(?=Contains|EndsWith|StartsWith))(Contains|EndsWith|StartsWith)([a-zA-Z0-9. \-\_]+)/g;
         let rule: IPredicate = null;
         let matches = reg.exec(visibleRule);
         if (matches && matches.length === 10) {


### PR DESCRIPTION
Visibility rules for the the task.json (ie [when building a custom AzDO task](https://docs.microsoft.com/en-us/azure/devops/extend/develop/add-build-task?view=azure-devops#taskjson)) currently only allow for alphanumeric characters and spaces. 

This is very limiting if you have a string on the other side of the conditional - `someVariable = my_value` or `someVariableName != some-guid-goes-here` . Proposing to include hyphens and underscores to be more inclusive and therefore more flexible for options. The left side of the operation can stay alphanumeric-and-space, but the contents on the right side should be more flexible than it currently is.

See this issue in azure-pipelines-task-lib: https://github.com/microsoft/azure-pipelines-task-lib/issues/658 Someone there requested `#` to be a viable character but may be something to consider later?